### PR TITLE
Fix subchannels (i.e. HDHomeRun) mappings being set as blanks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:apache-buster
+FROM php:8.0-apache-bullseye
 
 # Arguments defined in docker-compose.yml
 ARG user

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -77,7 +77,8 @@ class ChannelController extends Controller
 
         $data = [];
         foreach($channelMaps as $guideNumberIdx => $mappedNumber) {
-            list(,,,$guideNumber) = explode('_', $guideNumberIdx);
+            list(,,,$guideNumber) = explode('_', $guideNumberIdx, 4);
+            $guideNumber = str_replace('_', '.', $guideNumber);
             $data[] = [
                 'guide_number' => $guideNumber,
                 'mapped_channel_number' => $mappedNumber ?? $guideNumber,


### PR DESCRIPTION
Fixes subchannels not being mapped and reverted to a blank due to subchannels containing a dot. PHP replaces the dot with an underscore in array element names during POSTing of the channel mappings, this PR corrects this to ensure subchannels are saved with the original dot to the database. See https://community.getchannels.com/t/remapping-channel-numbers/24698/77.

This PR also updates the container to use Debian Bullseye, and specifies PHP 8.0.x as currently the container cannot start as-is due to composer not being able to handle PHP 8.2 (current version).